### PR TITLE
0.7-store bind in credhub optional

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -305,16 +305,6 @@ This is the username that <%= vars.product_short %> uses to push and pull images
 1. Enter the **Registry Password**.
 This is the password that <%= vars.product_short %> uses to push and pull images to the private container registry.
 
-### <a id="advanced-config"></a>Advanced Configuration
-
-Most installations should leave the default for "Store Bind Credentials" turned on.
-Bind credentials will then be stored in Credhub and therefore more secure. 
-
-Only turn this off if you have special integration requirements where Credhub cannot be used. 
-
-Once the tile is installed with a given "Store Bind Credentials" setting, it should not be changed. 
-
-
 ### <a id="errands"></a>Errands
 
 The pre-delete errand `deregistar` removes the pre-provisioned Kubernetes service from `cf marketplace`

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -305,6 +305,16 @@ This is the username that <%= vars.product_short %> uses to push and pull images
 1. Enter the **Registry Password**.
 This is the password that <%= vars.product_short %> uses to push and pull images to the private container registry.
 
+### <a id="advanced-config"></a>Advanced Configuration
+
+Most installations should leave the default for "Store Bind Credentials" turned on.
+Bind credentials will then be stored in Credhub and therefore more secure. 
+
+Only turn this off if you have special integration requirements where Credhub cannot be used. 
+
+Once the tile is installed with a given "Store Bind Credentials" setting, it should not be changed. 
+
+
 ### <a id="errands"></a>Errands
 
 The pre-delete errand `deregistar` removes the pre-provisioned Kubernetes service from `cf marketplace`


### PR DESCRIPTION
Add documentation for Tile Configuration to make optional storing bindings in Credhub