### PR TITLE
Indicate tested Kubernetes versions

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -61,6 +61,10 @@ The following table provides version and version-support information about <%= v
         <td>1.7, 1.6, 1.5, 1.4, and 1.3</td>
     </tr>
     <tr>
+        <td>Compatible Kubernetes versions</td>
+        <td>1.13 through 1.18</td>
+    </tr>
+    <tr>
         <td>IaaS support</td>
         <td>AWS, Azure, GCP, OpenStack, and vSphere</td>
     </tr>


### PR DESCRIPTION
Co-authored-by: Matt Cholick <mcholick@vmware.com>

Should this be merged to any other branches? yes, applies to 0.10 and 0.11
