### PR TITLE
Update installing-dev.html.md.erb

### DIFF
--- a/installing-dev.html.md.erb
+++ b/installing-dev.html.md.erb
@@ -250,8 +250,8 @@ To install the <%= vars.product_short %> Helm chart:
       --set cf.brokerUrl="http://${BROKER_IP}" \
       --set cf.brokerName=<%= vars.product_cli %> \
       --set cf.apiAddress=http://api.SYSTEM-DOMAIN \
-      --set cf.client=CF-USERNAME \
-      --set cf.clientSecret=CF-PASSWORD \
+      --set cf.username=CF-USERNAME \
+      --set cf.password=CF-PASSWORD \
       --set cf.skipSslValidation=true \
       -n <%= vars.product_short %>-NAMESPACE
     ```


### PR DESCRIPTION
[#174821016](https://www.pivotaltracker.com/n/projects/2195630/stories/174821016)

[from slack](https://vmware.slack.com/archives/CJ133JQQL/p1600172043024800)

We currently recommend `client` `clientSecret` for the dev install, this is incorrect. We should use `cf.username` and `cf.password`.
```
helm upgrade RELEASE-NAME tsmgr-VERSION-NUMBER.tgz --reuse-values \
  --set cf.brokerUrl="http://${BROKER_IP}" \
  --set cf.brokerName=tsmgr \
  --set cf.apiAddress=http://api.SYSTEM-DOMAIN \
  --set cf.client=CF-USERNAME \
  --set cf.clientSecret=CF-PASSWORD \
  --set cf.skipSslValidation=true \
  -n TSMGR-NAMESPACE
```

---
Acceptance

1. Fixed in the docs 