### PR TITLE
Fix the `Get your server and certificate authority` instructions to c…

### DIFF
--- a/managing-clusters.html.md.erb
+++ b/managing-clusters.html.md.erb
@@ -41,10 +41,10 @@ To create a cluster credentials file:
 
     echo "Using cluster $cluster"
 
-    server=`grep -B 2 "name: $cluster" $kube_config \
+    server=`grep -B 2 "name: $cluster\$" $kube_config \
       |grep server|sed "s/ //g"|sed "s/^[^:]*://g"`
 
-    certificate=`grep -B 2 "name: $cluster" $kube_config \
+    certificate=`grep -B 2 "name: $cluster\$" $kube_config \
       |grep certificate|sed "s/ //g"|sed "s/.*://"`
     ```
 


### PR DESCRIPTION
…reate a good cluster-creds.yaml when cluster name greps more than 1 cluster in k8s config file

- Added end of the line character to avoid getting duplicated data when the cluster name matches two different configurations, for example there is a cluster named tests and another called test, if test is the current, it would

[#174886278]

Should this be merged to any other branches? Yes
