### PR TITLE
No longer have the option of downloading images from pivnet.

### DIFF
--- a/installing-dev.html.md.erb
+++ b/installing-dev.html.md.erb
@@ -79,30 +79,27 @@ more visibility into the process.
 
 ### <a id="install-dev"></a> Install Using the install-dev.sh Script
 
-This approach requires a private image registry that uploads the Docker installation images.
-To use the `install-dev.sh` script to install <%= vars.product_short %>:
+To install using the `install-dev.sh` script:
 
-1. Verify and record your private registry endpoint, username, and password.
-
-1. Go to [<%= vars.product_network %>](https://network.pivotal.io/products/tanzu-service-manager).
-
-1. Sign in, if you are not already signed in.
-
-1. Download:
+1. Download artifacts from [<%= vars.product_network %>](https://network.pivotal.io/products/tanzu-service-manager) to an empty directory:
     * **The <%= vars.product_short %> Command Line Interface (CLI):** Click **CLIs** and download
     the CLI for your operating system.
     * **<%= vars.product_short %> Helm chart TGZ file:** Click
     **Helm Chart for <%= vars.product_short %>** and download the Helm chart TGZ file.
-    * **Images**: Click **Images** and download the daemon, broker, Minio, and ChartMuseum Docker
-    images.
     * **install-dev.sh script**: Click **<%= vars.product_short %> Dev Environment Installer** and
     download the `install-dev.sh` file.
+    
+1. Do a `docker login registry.pivotal.io` so that the script can pull the necessary installation images. The credentials will 
+be the same as the <%= vars.product_network %> credentials.
 
 1. Make the `install-dev.sh` file executable by running:
 
     ```
     chmod +x install-dev.sh
     ```
+
+1. This approach requires a private image registry that uploads the Docker installation images.
+Verify and record your private registry endpoint, username, and password.
 
 1. Provide the registry endpoint, username, and password during the installation by doing one of these
 methods:
@@ -111,7 +108,7 @@ methods:
         ./install-dev.sh
         ```
         and then answer the registry details questions
-    * Create a `registry.yaml` file containing the needed information.
+    * OR create a `registry.yaml` file containing the needed information.
     See an example `registry.yaml` template below:
 
         ```yaml

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -88,7 +88,6 @@ To get the resources needed from <%= vars.product_network %> to install <%= vars
     the CLI for your operating system.
     + **Docker `pull` commands:** Click **Artifact References** and record the `docker pull`
     commands for the **broker**, **daemon**, and **chartmuseum**.
-    You can alternatively download the image `tgz` files from the `images` directory.
     + **Helm chart TGZ file:** Click **<%= vars.product_cli %>-VERSION-NUMBER.tgz** and download the
     Helm chart
     for <%= vars.product_short %>.
@@ -126,16 +125,8 @@ To install the <%= vars.product_short %> Command Line Interface (CLI):
 To replicate your <%= vars.product_short %> images to a private container image registry:
 
 1. Relocate the images to your local machine:
-    * If you recorded the `docker pull` commands in
-    [Get <%= vars.product_short %> Resources From <%= vars.product_network %>](#get) above,
-    run the `docker pull` commands to pull the images.
-    The registry credentials are the same as your <%= vars.product_network %> credentials.
-    * If you downloaded the `tgz` files instead of the `docker pull` commands,
-    load those images by running:
-
-        ```
-        docker load -i PATH-TO-TGZ-FILES
-        ```
+    Run the `docker pull` commands recorded in [Get <%= vars.product_short %> Resources From <%= vars.product_network %>](#get) above,
+    to pull the images. The registry credentials are the same as your <%= vars.product_network %> credentials.
 
 1. Tag the images for your registry by running these commands:
 


### PR DESCRIPTION
Co-authored-by: Eduardo Oliveira <edeoliveira@vmware.com>

Which other branches should this be merged with (if any)? Please backport to 1.0.1
