### PR TITLE
Command fixes

### DIFF
--- a/installing-dev.html.md.erb
+++ b/installing-dev.html.md.erb
@@ -135,14 +135,14 @@ methods:
 running:
 
     ```
-    kubectl get services -n tsmgr-dev
+    kubectl get services -n <%= vars.product_cli %>-dev
     ```
 
 1. After the external IP address is available for the daemon, configure the <%= vars.product_short %>
 environment variables by running:
 
     ```
-    source ./set-tsmgr-env.sh
+    source ./set-<%= vars.product_cli %>-env.sh
     ```
 
 1. After the external IP address is available for the broker, configure

--- a/installing-dev.html.md.erb
+++ b/installing-dev.html.md.erb
@@ -142,7 +142,7 @@ running:
 environment variables by running:
 
     ```
-    source ./set-sm-env.sh
+    source ./set-tsmgr-env.sh
     ```
 
 1. After the external IP address is available for the broker, configure

--- a/installing-dev.html.md.erb
+++ b/installing-dev.html.md.erb
@@ -100,7 +100,7 @@ To install using the `install-dev.sh` script:
 1. Make the `install-dev.sh` file executable by running:
 
     ```
-    chmod +x install-dev.sh
+    chmod +x install-dev-<version>.sh
     ```
 
 1. For the private image registry that you will use to upload the Docker installation images,
@@ -135,7 +135,7 @@ methods:
 running:
 
     ```
-    kubectl get services -n <%= vars.product_short %>-dev
+    kubectl get services -n tsmgr-dev
     ```
 
 1. After the external IP address is available for the daemon, configure the <%= vars.product_short %>


### PR DESCRIPTION
the `install-dev.sh` has a version in it when downloaded which should be accounted for. The `<%= vars.product_short %>` substitution returns a capitalized version of the product name which does not match the namespace name.

Which other branches should this be merged with (if any)?
